### PR TITLE
[doc] add spoilers: template literals verbatim, C++, output preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NwSJS
 
 ## No White Space JavaScript
-Simple, lightweight, ES6 compliant, cross-platform CLI utility to strip whitespace and comments from Javascript source code.  
+Simple, lightweight, ES6 compliant, cross-platform CLI utility to strip whitespace and comments from Javascript source code.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/j59s8ni4iimacqkt?svg=true)](https://ci.appveyor.com/project/chgibb/nwsjs)
 [![Build Status](https://travis-ci.org/chgibb/NwSJS.svg?branch=master)](https://travis-ci.org/chgibb/NwSJS)
@@ -9,18 +9,23 @@ Simple, lightweight, ES6 compliant, cross-platform CLI utility to strip whitespa
 
 [![NPM](https://nodei.co/npm/nwsjs.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/nwsjs/)
 
+* Copies template literals (multiline strings) verbatim.
+* Written in C++. If you prefer a JS version, nowadays there's
+  [uglify-es](https://www.npmjs.com/package/uglify-es).
+* Output preview: [test inputs](tests/) -> [outputs](docs/preview/)
+
 ## Usage
 ### Running
 #### Linux
-``` 
+```
 $ ./nwsjs srcFile.js > outFile.js
 ```
 #### Windows
-``` 
+```
 > nwsjs.exe srcFile.js > outFile.js
 ```
-Note: srcFile.js and outFile.js must NOT be the same file!  
-### Using From NPM  
+Note: srcFile.js and outFile.js must NOT be the same file!
+### Using From NPM
 ### Installing
 #### Linux
 ```
@@ -78,7 +83,7 @@ npm test
 Note: For Windows users, running tests requires the availability of a valid ```bash.exe``` on your ```%PATH%```.
 
 ### Testing Process
-NwSJS is tested against Microsoft's Typescript compiler and the Browserify Javascript bundler. Every .js file pulled in by Typescript, Browserify, as well as the various front end and backend frameworks pulled in by the test files are first compressed. The .ts files under tests are then compiled. If NwSJS crashes or the compiler raises an error while compiling then the test fails.  
+NwSJS is tested against Microsoft's Typescript compiler and the Browserify Javascript bundler. Every .js file pulled in by Typescript, Browserify, as well as the various front end and backend frameworks pulled in by the test files are first compressed. The .ts files under tests are then compiled. If NwSJS crashes or the compiler raises an error while compiling then the test fails.
 
 Each compiled .ts file is then bundled using Browserify. The resulting bundles are then compressed. The compressed and uncompressed bundles are run and their return codes are compared. If the return codes differ, then the test fails.
 

--- a/docs/preview/nws.test1.ts
+++ b/docs/preview/nws.test1.ts
@@ -1,0 +1,4 @@
+require("angular");require("jquery");class HelloWorld
+{public constructor()
+{console.log("Hello World");}}
+let helloWorld :HelloWorld=new HelloWorld();

--- a/docs/preview/nws.test2.ts
+++ b/docs/preview/nws.test2.ts
@@ -1,0 +1,2 @@
+require("fs-extra");require("minimist");require("rimraf");
+console.log("Hello World2");

--- a/docs/preview/upd.wine.sh
+++ b/docs/preview/upd.wine.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# -*- coding: utf-8, tab-width: 2 -*-
+#
+# Using wine and the win32 version as fallback in case of
+# https://github.com/chgibb/NwSJS/issues/14
+
+NWSJS_CMD=nwsjs
+<<<';' $NWSJS_CMD &>/dev/null
+[ $? == 126 ] && NWSJS_CMD="wine $(which nwsjs.exe)"
+
+for FN in ../../tests/*.[tj]s; do
+  $NWSJS_CMD "$FN" >nws."$(basename "$FN")"
+done


### PR DESCRIPTION
Fixes #13 and also adds some more hints that I'd have wished to read when I discovered it on npm.
For 2 of 3 tests I was able to get an output preview by running the win32 version in wine. For test 3 it only printed a blank line however.